### PR TITLE
Updated the workflow to use the commit id as release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "release.zip"
-          tag: ${{ github.event.ref }}
+          tag: ${{ github.event.commits.timestamp }}
           token: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           artifacts: "release.zip"
           tag: ${{ github.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "release.zip"
-          tag: ${{ github.run_attempt }}
+          tag: ${{ github.event.ref }}
           token: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Create Archive
 
 on: 
   push:
-    tags:
-    - '*'
+
     
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
         uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "release.zip"
-          tag: ${{ github.sha }}
+          tag: ${{ github.run_attempt }}
           token: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,13 @@ name: Create Archive
 on: 
   push:
 
-    
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2  # Use v2 instead of specifying 'master'
+        uses: actions/checkout@v2
 
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.5
@@ -19,9 +18,13 @@ jobs:
           filename: 'release.zip'
           exclusions: '*.git* /*node_modules/* .editorconfig'
 
+      - name: Get Commit ID
+        id: get_commit_id
+        run: echo "COMMIT_ID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Upload Release
         uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "release.zip"
-          tag: ${{ github.event.commits.timestamp }}
-          token: ${{ secrets.TOKEN }}
+          tag: ${{ env.COMMIT_ID }}  # Use the environment variable for the tag
+          token: ${{ secrets.TOKEN }}  # Use your custom token


### PR DESCRIPTION
It took me a while but i settled on the idea of using commit id as release tag, keeps it distinct